### PR TITLE
Worker_processes set to auto

### DIFF
--- a/vh-nginx/nginx_templates.py
+++ b/vh-nginx/nginx_templates.py
@@ -3,6 +3,7 @@ TEMPLATE_CONFIG_FILE = """
 
 user %(user)s %(user)s;
 pid /var/run/nginx.pid;
+worker_processes auto;
 worker_rlimit_nofile 100000;
 
 events {


### PR DESCRIPTION
Worker_processes set to auto to automatically spawn work process according to available cpu cores.
