### PR TITLE
[php] update conf files for php-fpm 5.5.12

### DIFF
--- a/vh-php-fpm/phpfpm.py
+++ b/vh-php-fpm/phpfpm.py
@@ -15,7 +15,11 @@ error_log = /var/log/php5-fpm.log
 [global-pool]
 user = www-data
 group = www-data
+
 listen = /var/run/php-fcgi.sock
+listen.owner = www-data
+listen.group = www-data
+listen.mode = 0660
 
 pm = dynamic
 pm.start_servers = 1
@@ -32,6 +36,9 @@ user = www-data
 group = www-data
 
 listen = /var/run/php-fcgi-%(name)s.sock
+listen.owner = www-data
+listen.group = www-data
+listen.mode = 0660
 
 pm = dynamic
 pm.max_children = %(max)s


### PR DESCRIPTION
socket file is now root by default, listen.owner and listen.group have to be set.
Source : http://www.dotdeb.org/2014/05/07/php-5-5-12-for-debian-wheezy/
