### PR TITLE
[nginx] add svg mime type

### DIFF
--- a/vh-nginx/nginx_templates.py
+++ b/vh-nginx/nginx_templates.py
@@ -115,6 +115,7 @@ types {
     text/x-component                      htc;
     text/mathml                           mml;
     image/png                             png;
+    image/svg+xml                         svg svgz;
     image/x-icon                          ico;
     image/x-jng                           jng;
     image/vnd.wap.wbmp                    wbmp;


### PR DESCRIPTION
Just adds a missing svg mime type to the nginx conf file
