### PR TITLE
Fix for reverse proxied SSL sites

### DIFF
--- a/vh-nginx/nginx_templates.py
+++ b/vh-nginx/nginx_templates.py
@@ -206,6 +206,7 @@ TEMPLATE_LOCATION_CONTENT_PROXY = """
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header HTTPS   $https;
 """
 
 TEMPLATE_LOCATION_CONTENT_FCGI = """


### PR DESCRIPTION
This fix helps us use the same content reverse proxy for both SSL/Non ssl sites and backend sites can use this Header to know if they serve https or http.. important for magento or shopping sites.
