### PR TITLE
Change 'default' to 'default_server"

### DIFF
--- a/vh-nginx/nginx.py
+++ b/vh-nginx/nginx.py
@@ -117,7 +117,7 @@ class NginxWebserver (WebserverComponent):
                         x.host, x.port,
                         ' ssl' if x.ssl else '',
                         ' spdy' if x.spdy else '',
-                        ' default' if x.default else '',
+                        ' default_server' if x.default else '',
                     )
                     for x in website.ports
                 )


### PR DESCRIPTION
The default flag for the listen statement has been changed to 'default_server' in Nginx version 0.8.21
