### PR TITLE
Add the possibility to define user and group on php-fpm (default still www-data)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.m.js
 build
 dist
+.idea

--- a/vh-php-fpm/phpfpm.py
+++ b/vh-php-fpm/phpfpm.py
@@ -32,8 +32,8 @@ pm.max_spare_servers = 5
 
 TEMPLATE_POOL = """
 [%(name)s]
-user = www-data
-group = www-data
+user = %(user)s
+group = %(group)s
 
 listen = /var/run/php-fcgi-%(name)s.sock
 listen.owner = www-data
@@ -82,6 +82,8 @@ class PHPFPM (ApplicationGatewayComponent):
     def __generate_pool(self, location, backend, name):
         pm_min = backend.params.get('pm_min', 1) or 1
         pm_max = backend.params.get('pm_max', 5) or 5
+        pm_user = backend.params.get('pm_user', 'www-data') or 'www-data'
+        pm_group = backend.params.get('pm_group', 'www-data') or 'www-data'
 
         extras = ''
 
@@ -103,6 +105,8 @@ class PHPFPM (ApplicationGatewayComponent):
             'name': name,
             'min': pm_min,
             'max': pm_max,
+            'user': pm_user,
+            'group': pm_group,
             'sp_min': min(2, pm_min),
             'sp_max': min(6, pm_max),
             'php_open_basedir': open_basedir,

--- a/vh/layout/main-backend-params-php-fcgi.xml
+++ b/vh/layout/main-backend-params-php-fcgi.xml
@@ -12,6 +12,12 @@
                 <formline text="{Max processes}">
                     <textbox bind="pm_max" type="integer" />
                 </formline>
+	            <formline text="{User processes}">
+		            <textbox bind="pm_user" type="text" />
+	            </formline>
+	            <formline text="{Group processes}">
+		            <textbox bind="pm_group" type="text" />
+	            </formline>
             </vc>
         </bind:dict>
     </collapserow>


### PR DESCRIPTION
Hello.
I manage my websites with a chroot on each users and each website run on a php-fpm launched with a specified user.
So, I add a couple of line to do this job, maybe it can be usefull for someone else :-)
