### PR TITLE
Using mailroot/domain.com/name format for email box for better management

### DIFF
--- a/vh-mail/templates.py
+++ b/vh-mail/templates.py
@@ -304,7 +304,7 @@ vmail:
   driver = appendfile
   user = mail
   maildir_format = true
-  directory = %(mailroot)s/$local_part@$domain
+  directory = %(mailroot)s/$domain/$local_part
   create_directory
   delivery_date_add
   envelope_to_add


### PR DESCRIPTION
Instead of using mailroot/name@domain.com, use mailroot/domain.com/name.
