### PR TITLE
Add TLS support to pureftpd plugin

### DIFF
--- a/vh-pureftpd/pureftpd.py
+++ b/vh-pureftpd/pureftpd.py
@@ -64,7 +64,8 @@ AllowUserFXP                yes
 ProhibitDotFilesWrite       no
 ProhibitDotFilesRead        no
 AutoRename                  no
-AltLog                     clf:/var/log/pureftpd.log
+AltLog                      clf:/var/log/pureftpd.log
+TLS                         1
 """
 
 


### PR DESCRIPTION
Allow standard and TLS connections for PureFTPD.

It may be nice to have the possibility to choose for TLS only or not, I will take a look if I have time for that.