### PR TITLE
Fix MariaDB deps for using official MariaDB repos

### DIFF
--- a/vh-mysql/package.desc
+++ b/vh-mysql/package.desc
@@ -1,7 +1,7 @@
 PACKAGE=ajenti-v-mysql
 VERSION=0.3.4
 DEB_DEPENDS="ajenti-v (>=0.2.34), mysql-server|mariadb-server, mysql-client|mariadb-client"
-RPM_DEPENDS="ajenti-v >= 0.2.34, mysql-server|mariadb-server, mysql|mariadb-client"
+RPM_DEPENDS="ajenti-v >= 0.2.34, mysql-server|mariadb-server|MariaDB-server, mysql|mariadb-client|MariaDB-client"
 PROVIDES=ajenti-v-db
 DESCRIPTION="MySQL support for Ajenti V"
 read -d '' POSTINST <<END


### PR DESCRIPTION
The official MariaDB repositories for Fedora supply a slightly different package name than the default packages.  I'm proposing that both names be included to enable compatibility with these repos.

Maria Repos tool (for reference):
https://downloads.mariadb.org/mariadb/repositories/#distro=Fedora&distro_release=fedora20-amd64--fedora20&version=10.0