### PR TITLE
Add HTTP/2 to nginx config

### DIFF
--- a/vh-nginx/nginx.py
+++ b/vh-nginx/nginx.py
@@ -114,10 +114,11 @@ class NginxWebserver (WebserverComponent):
             ) if website.domains else '',
             'ports': (
                 '\n'.join(
-                    'listen %s:%s%s%s%s;' % (
+                    'listen %s:%s%s%s%s%s;' % (
                         x.host, x.port,
                         ' ssl' if x.ssl else '',
                         ' spdy' if x.spdy else '',
+                        ' http2' if x.http2 else '',
                         ' default_server' if x.default else '',
                     )
                     for x in website.ports

--- a/vh/layout/main-website.xml
+++ b/vh/layout/main-website.xml
@@ -97,6 +97,7 @@
                                 <dth text="{Port}" />
                                 <dth text="SSL" />
                                 <dth text="SPDY" />
+                                <dth text="HTTP2" />
                                 <dth text="Default" />
                                 <dth />
                             </dtr>
@@ -118,6 +119,9 @@
                                 </dtd>
                                 <dtd>
                                     <checkbox bind="spdy" />
+                                </dtd>
+                                <dtd>
+                                    <checkbox bind="http2" />
                                 </dtd>
                                 <dtd>
                                     <checkbox bind="default" />


### PR DESCRIPTION
This adds http2 to nginx config.

You must have the right nginx version to enable this settings, just like you have to have the right version to enable spdy (witch fails on too earlier or too recent versions).

This target and fix #188 