### PR TITLE
Fix indentation fails

### DIFF
--- a/vh-nginx/nginx.py
+++ b/vh-nginx/nginx.py
@@ -69,7 +69,7 @@ class NginxWebserver (WebserverComponent):
                 'id': location.backend.id,
             }
 
-	    if location.backend.type == 'php7.0-fcgi':
+        if location.backend.type == 'php7.0-fcgi':
             content = TEMPLATE_LOCATION_CONTENT_PHP70_FCGI % {
                 'id': location.backend.id,
             }


### PR DESCRIPTION
This cause this error log and the nginx plugin crash : 

```
2016-01-27 13:19:38,464 WARNING  __init__.load():  *** [vh-nginx] Plugin crashed: crashed: expected an indented block (nginx.py, line 73)
Traceback (most recent call last):
  File "/usr/lib/pymodules/python2.7/ajenti/plugins/__init__.py", line 328, in load
    info.init()
  File "/var/lib/ajenti/plugins/vh-nginx/__init__.py", line 21, in init
    import nginx
  File "/usr/local/lib/python2.7/dist-packages/gevent-1.1b4-py2.7-linux-x86_64.egg/gevent/builtins.py", line 53, in __import__
    result = _import(*args, **kwargs)
  File "/var/lib/ajenti/plugins/vh-nginx/nginx.py", line 73
    content = TEMPLATE_LOCATION_CONTENT_PHP70_FCGI % {
          ^
IndentationError: expected an indented block
```
