### PR TITLE
NVM support

### DIFF
--- a/vh-nodejs/package.desc
+++ b/vh-nodejs/package.desc
@@ -1,5 +1,5 @@
 PACKAGE=ajenti-v-nodejs
-VERSION=0.1.9
+VERSION=0.2.0
 DEB_DEPENDS="ajenti-v, supervisor"
 RPM_DEPENDS="ajenti-v, supervisor"
 PROVIDES=ajenti-v-appgate

--- a/vh/layout/main-backend-params-nodejs.xml
+++ b/vh/layout/main-backend-params-nodejs.xml
@@ -1,16 +1,32 @@
-<box binder:context="params">
-    <vc>
-        <formline text="{Script name}">
-            <textbox bind="[script]" />
-        </formline>
-        <formline text="{Script's HTTP port}">
-            <textbox bind="[port]" type="integer" />
-        </formline>
-        <formline text="{Environment}">
-            <textbox bind="[environment]" />
-        </formline>
-        <formline text="{Process user}">
-            <textbox bind="[user]" />
-        </formline>
-    </vc>
+<box>
+    <bind:dict bind="params">
+        <vc>
+            <formline text="{Script name}">
+                <textbox bind="[script]" />
+            </formline>
+            <formline text="{Script's HTTP port}">
+                <textbox bind="[port]" type="integer" />
+            </formline>
+            <formline text="{Environment}">
+                <textbox bind="[environment]" />
+            </formline>
+            <dt filtering="False">
+                <collapserow>
+                    <hc>
+                        <icon icon="cog" />
+                        <label text="Node" />
+                    </hc>
+                    <formline text="{Nvm path}">
+                        <pathbox bind="venv" directory="True" />
+                    </formline>
+                    <formline text="{Username}">
+                        <textbox bind="username" />
+                    </formline>
+                    <formline text="{Custom configuration}">
+                        <codearea bind="custom_conf" />
+                    </formline>
+                </collapserow>
+            </dt>
+        </vc>
+    </bind:dict>
 </box>


### PR DESCRIPTION
This pull enables support for Node Version Manager by specifying a path to the node binary like Ajenti-v already does for virtualenv.
Reference:

- https://github.com/creationix/nvm
- https://www.digitalocean.com/community/tutorials/how-to-install-node-js-with-nvm-node-version-manager-on-a-vps