### PR TITLE
Encrypted Mailbox Passwords

### DIFF
--- a/vh-mail/api.py
+++ b/vh-mail/api.py
@@ -289,21 +289,26 @@ class MailEximCourierBackend (MailBackend):
                 'home=%s' % root,
                 'mail=%s' % root,
             ])
-
-            udbpw = subprocess.Popen(
-                ['userdbpw', '-md5'],
-                stdout=subprocess.PIPE,
-                stdin=subprocess.PIPE
-            )
-            o, e = udbpw.communicate(
-                '%s\n%s\n' % (mb.password, mb.password)
-            )
-            md5pw = o
+            
+            if mb.password[:len("md5|")]=="md5|":    #Check if the stored password is encrypted with md5 algorithm already
+                md5pw=mb.password[len("md5|"):]
+                
+            else:                                    #If stored password is not encrypted (i.e. plaintext), then encrypty it with md5
+                udbpw = subprocess.Popen(
+                    ['userdbpw', '-md5'],
+                    stdout=subprocess.PIPE,
+                    stdin=subprocess.PIPE
+                )
+                o, e = udbpw.communicate(
+                    '%s\n%s\n' % (mb.password, mb.password)
+                )
+                md5pw = o
 
             udb = subprocess.Popen(
-                ['userdb', mb.name, 'set', 'systempw'],
-                stdin=subprocess.PIPE
+               ['userdb', mb.name, 'set', 'systempw'],
+               stdin=subprocess.PIPE
             )
+                
             udb.communicate(md5pw)
 
         if os.path.exists(self.courier_userdb):

--- a/vh-mail/api.py
+++ b/vh-mail/api.py
@@ -289,26 +289,21 @@ class MailEximCourierBackend (MailBackend):
                 'home=%s' % root,
                 'mail=%s' % root,
             ])
-            
-            if mb.password[:len("md5|")]=="md5|":    #Check if the stored password is encrypted with md5 algorithm already
-                md5pw=mb.password[len("md5|"):]
-                
-            else:                                    #If stored password is not encrypted (i.e. plaintext), then encrypty it with md5
-                udbpw = subprocess.Popen(
-                    ['userdbpw', '-md5'],
-                    stdout=subprocess.PIPE,
-                    stdin=subprocess.PIPE
-                )
-                o, e = udbpw.communicate(
-                    '%s\n%s\n' % (mb.password, mb.password)
-                )
-                md5pw = o
+
+            udbpw = subprocess.Popen(
+                ['userdbpw', '-md5'],
+                stdout=subprocess.PIPE,
+                stdin=subprocess.PIPE
+            )
+            o, e = udbpw.communicate(
+                '%s\n%s\n' % (mb.password, mb.password)
+            )
+            md5pw = o
 
             udb = subprocess.Popen(
-               ['userdb', mb.name, 'set', 'systempw'],
-               stdin=subprocess.PIPE
+                ['userdb', mb.name, 'set', 'systempw'],
+                stdin=subprocess.PIPE
             )
-                
             udb.communicate(md5pw)
 
         if os.path.exists(self.courier_userdb):

--- a/vh-mail/main.py
+++ b/vh-mail/main.py
@@ -44,16 +44,6 @@ class MailPlugin (SectionPlugin):
         def post_mb_update(object, collection, item, ui):
             if ui.find('password').value:
                 item.password = ui.find('password').value
-                if item.password[:len("md5|")]!="md5|":       #If the password is not encrypted as md5, then encrypt it using userdbpw for consistency
-                    udbpw = subprocess.Popen(
-                        ['userdbpw', '-md5'],
-                        stdout=subprocess.PIPE,
-                        stdin=subprocess.PIPE
-                    )
-                    o, e = udbpw.communicate(
-                        '%s\n%s\n' % (item.password, item.password)
-                    )
-                    item.password = "md5|"+o        #Prefix the hash with "md5|"
 
         self.find('mailboxes').post_item_bind = post_mb_bind
         self.find('mailboxes').post_item_update = post_mb_update

--- a/vh-mail/main.py
+++ b/vh-mail/main.py
@@ -44,6 +44,16 @@ class MailPlugin (SectionPlugin):
         def post_mb_update(object, collection, item, ui):
             if ui.find('password').value:
                 item.password = ui.find('password').value
+                if item.password[:len("md5|")]!="md5|":       #If the password is not encrypted as md5, then encrypt it using userdbpw for consistency
+                    udbpw = subprocess.Popen(
+                        ['userdbpw', '-md5'],
+                        stdout=subprocess.PIPE,
+                        stdin=subprocess.PIPE
+                    )
+                    o, e = udbpw.communicate(
+                        '%s\n%s\n' % (item.password, item.password)
+                    )
+                    item.password = "md5|"+o        #Prefix the hash with "md5|"
 
         self.find('mailboxes').post_item_bind = post_mb_bind
         self.find('mailboxes').post_item_update = post_mb_update


### PR DESCRIPTION
This pull request makes Ajenti-V store mailbox passwords with MD5 hashing instead of plaintext. Default behavior is that when a password is entered for a new account or a password is changed in the GUI, it will keep its MD5 hash instead of plaintext from now on.

Passwords stored as plaintext will remain as plaintext for compatibility, unless changed on the Mail page in Ajenti.

While recreating the courier userdb, plaintext and MD5 passwords are properly handled so plaintext passwords still work and MD5 passwords are not double-hashed.

![improved-mail](https://cloud.githubusercontent.com/assets/18250141/15480520/04092c2e-20f4-11e6-985a-a74babeefe9a.PNG)

Here you can see the mail.json where Ajenti stores all of the mail configurations.
johndoe and janedoe have their passwords encrypted (as shown with md5 prefix), while hodor still has a plaintext password and they all can happily use their mailboxes.