### PR TITLE
Add templates for php5.6 and php7.0

### DIFF
--- a/vh/api.py
+++ b/vh/api.py
@@ -138,6 +138,30 @@ class WebsiteLocation (object):
                     }
                 }).save(),
             },
+            'php5.6-fcgi': {
+                'pattern': r'[^/]\.php(/|$)',
+                'path_append_pattern': False,
+                'match': 'regex',
+                'backend': Backend(None, {
+                    'type': 'static',
+                    'params': {
+                        'pm': 'dynamic',
+                        'php_admin_values': 'open_basedir = none;',
+                    }
+                }).save(),
+            },
+            'php7.0-fcgi': {
+                'pattern': r'[^/]\.php(/|$)',
+                'path_append_pattern': False,
+                'match': 'regex',
+                'backend': Backend(None, {
+                    'type': 'static',
+                    'params': {
+                        'pm': 'dynamic',
+                        'php_admin_values': 'open_basedir = none;',
+                    }
+                }).save(),
+            },
         }
 
         default_template = {


### PR DESCRIPTION
After adding a few few websites running on php 7.0 i got a bit annoyed by the fact that the template for 7 and 5.6 didn't look like the default one. So i added them.