### PR TITLE
Allow for listening on custom socket on php-fpm

### DIFF
--- a/vh-nginx/nginx.py
+++ b/vh-nginx/nginx.py
@@ -61,17 +61,17 @@ class NginxWebserver (WebserverComponent):
 
         if location.backend.type == 'php-fcgi':
             content = TEMPLATE_LOCATION_CONTENT_PHP_FCGI % {
-                'id': location.backend.id,
+                'listen': location.backend.params.get('listen', 'unix:/var/run/ajenti-v-php-fcgi-' + location.backend.id + '.sock') or 'unix:/var/run/ajenti-v-php-fcgi-'+ location.backend.id + '.sock',
             }
             
         if location.backend.type == 'php5.6-fcgi':
             content = TEMPLATE_LOCATION_CONTENT_PHP56_FCGI % {
-                'id': location.backend.id,
+                'listen': location.backend.params.get('listen', 'unix:/var/run/ajenti-v-php5.6-fcgi-' + location.backend.id + '.sock') or 'unix:/var/run/ajenti-v-php5.6-fcgi-'+ location.backend.id + '.sock',
             }
 
         if location.backend.type == 'php7.0-fcgi':
             content = TEMPLATE_LOCATION_CONTENT_PHP70_FCGI % {
-                'id': location.backend.id,
+                'listen': location.backend.params.get('listen', 'unix:/var/run/ajenti-v-php7.0-fcgi-' + location.backend.id + '.sock') or 'unix:/var/run/ajenti-v-php7.0-fcgi-'+ location.backend.id + '.sock',
             }
 
         if location.backend.type == 'python-wsgi':

--- a/vh-nginx/nginx_templates.py
+++ b/vh-nginx/nginx_templates.py
@@ -238,21 +238,21 @@ TEMPLATE_LOCATION_CONTENT_FCGI = """
 TEMPLATE_LOCATION_CONTENT_PHP_FCGI = """
         fastcgi_index index.php;
         include fcgi.conf;
-        fastcgi_pass unix:/var/run/ajenti-v-php-fcgi-%(id)s.sock;
+        fastcgi_pass %(listen)s;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
 """
 
 TEMPLATE_LOCATION_CONTENT_PHP56_FCGI = """
         fastcgi_index index.php;
         include fcgi.conf;
-        fastcgi_pass unix:/var/run/ajenti-v-php5.6-fcgi-%(id)s.sock;
+        fastcgi_pass %(listen)s;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
 """
 
 TEMPLATE_LOCATION_CONTENT_PHP70_FCGI = """
         fastcgi_index index.php;
         include fcgi.conf;
-        fastcgi_pass unix:/var/run/ajenti-v-php7.0-fcgi-%(id)s.sock;
+        fastcgi_pass %(listen)s;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
 """
 

--- a/vh-php-fpm/phpfpm.py
+++ b/vh-php-fpm/phpfpm.py
@@ -35,7 +35,7 @@ TEMPLATE_POOL = """
 user = %(user)s
 group = %(group)s
 
-listen = /var/run/ajenti-v-php-fcgi-%(name)s.sock
+listen = %(listen)s
 listen.owner = www-data
 listen.group = www-data
 listen.mode = 0660
@@ -82,6 +82,7 @@ class PHPFPM (ApplicationGatewayComponent):
         pm_max = backend.params.get('pm_max', 5) or 5
         user = backend.params.get('user', 'www-data') or 'www-data'
         group = backend.params.get('group', 'www-data') or 'www-data'
+        listen = backend.params.get('listen', '/var/run/ajenti-v-php-fcgi-' + name + '.sock') or '/var/run/ajenti-v-php-fcgi-'+ name + '.sock'
 
         extras = ''
 
@@ -97,6 +98,7 @@ class PHPFPM (ApplicationGatewayComponent):
 
         return TEMPLATE_POOL % {
             'name': name,
+            'listen': listen,
             'min': pm_min,
             'max': pm_max,
             'user': user,

--- a/vh-php5.6-fpm/php56fpm.py
+++ b/vh-php5.6-fpm/php56fpm.py
@@ -35,7 +35,7 @@ TEMPLATE_POOL = """
 user = %(user)s
 group = %(group)s
 
-listen = /var/run/ajenti-v-php5.6-fcgi-%(name)s.sock
+listen = %(listen)s
 listen.owner = www-data
 listen.group = www-data
 listen.mode = 0660
@@ -74,6 +74,7 @@ class PHP56FPM (ApplicationGatewayComponent):
         pm_max = backend.params.get('pm_max', 5) or 5
         user = backend.params.get('user', 'www-data') or 'www-data'
         group = backend.params.get('group', 'www-data') or 'www-data'
+        listen = backend.params.get('listen', '/var/run/ajenti-v-php5.6-fcgi-' + name + '.sock') or '/var/run/ajenti-v-php5.6-fcgi-'+ name + '.sock'
 
         extras = ''
 
@@ -89,6 +90,7 @@ class PHP56FPM (ApplicationGatewayComponent):
 
         return TEMPLATE_POOL % {
             'name': name,
+            'listen': listen,
             'min': pm_min,
             'max': pm_max,
             'user': user,

--- a/vh-php7.0-fpm/php70fpm.py
+++ b/vh-php7.0-fpm/php70fpm.py
@@ -35,7 +35,7 @@ TEMPLATE_POOL = """
 user = %(user)s
 group = %(group)s
 
-listen = /var/run/ajenti-v-php7.0-fcgi-%(name)s.sock
+listen = %(listen)s
 listen.owner = www-data
 listen.group = www-data
 listen.mode = 0660
@@ -74,6 +74,7 @@ class PHP70FPM (ApplicationGatewayComponent):
         pm_max = backend.params.get('pm_max', 5) or 5
         user = backend.params.get('user', 'www-data') or 'www-data'
         group = backend.params.get('group', 'www-data') or 'www-data'
+        listen = backend.params.get('listen', '/var/run/ajenti-v-php7.0-fcgi-' + name + '.sock') or '/var/run/ajenti-v-php7.0-fcgi-'+ name + '.sock'
 
         extras = ''
 
@@ -89,6 +90,7 @@ class PHP70FPM (ApplicationGatewayComponent):
 
         return TEMPLATE_POOL % {
             'name': name,
+            'listen': listen,
             'min': pm_min,
             'max': pm_max,
             'user': user,

--- a/vh/layout/main-backend-params-php-fcgi.xml
+++ b/vh/layout/main-backend-params-php-fcgi.xml
@@ -23,6 +23,9 @@
             <formline text="{Process group}">
 	            <textbox bind="[group]" />
             </formline>
+            <formline text="{Custom listen}">
+	            <textbox bind="[listen]" />
+            </formline>
         </vc>
     </collapserow>
     <collapserow>

--- a/vh/layout/main-backend-params-php5.6-fcgi.xml
+++ b/vh/layout/main-backend-params-php5.6-fcgi.xml
@@ -23,6 +23,9 @@
             <formline text="{Process group}">
 	            <textbox bind="[group]" />
             </formline>
+            <formline text="{Custom listen}">
+	            <textbox bind="[listen]" />
+            </formline>
         </vc>
     </collapserow>
     <collapserow>

--- a/vh/layout/main-backend-params-php7.0-fcgi.xml
+++ b/vh/layout/main-backend-params-php7.0-fcgi.xml
@@ -23,6 +23,9 @@
             <formline text="{Process group}">
 	            <textbox bind="[group]" />
             </formline>
+            <formline text="{Custom listen}">
+	            <textbox bind="[listen]" />
+            </formline>
         </vc>
     </collapserow>
     <collapserow>


### PR DESCRIPTION
This commit changes the php-fpm listen and fcgi_pass logic so you can listen on a custom tcp socket, like 127.0.0.1:9000, fixing errors like this:

https://stackoverflow.com/questions/10470109/error-502-in-nginx-php5-fpm

I've tested this configuration and I'm currently runing it on my website. If "Custom listen" is not set, it will use unix sockets by default.