### PR TITLE
[vh-pureftpd] Allow binding system account/group to virtual user

### DIFF
--- a/vh-pureftpd/layout/ext.xml
+++ b/vh-pureftpd/layout/ext.xml
@@ -12,6 +12,12 @@
                     <formline text="{Path}">
                         <pathbox bind="path" directory="True" />
                     </formline>
+                    <formline text="{System user}">
+                        <textbox bind="system_user" />
+                    </formline>
+                    <formline text="{System group}">
+                        <textbox bind="system_group" />
+                    </formline>
                 </vc>
             </box>
         </pad>

--- a/vh-pureftpd/pureftpd.py
+++ b/vh-pureftpd/pureftpd.py
@@ -94,8 +94,8 @@ class PureFTPD (MiscComponent):
                     p = subprocess.Popen(
                         [
                             'pure-pw', 'useradd', cfg['username'], 
-                            '-u', cfg.get('system_user', 'www-data'),
-                            '-g', cfg.get('system_group', 'www-data'),
+                            '-u', cfg.get('system_user') or 'www-data',
+                            '-g', cfg.get('system_group') or 'www-data',
                             '-d', cfg.get('path', None) or website.root,
                         ],
                         stdin=subprocess.PIPE

--- a/vh-pureftpd/pureftpd.py
+++ b/vh-pureftpd/pureftpd.py
@@ -26,6 +26,13 @@ class PureFTPDExtension (BaseExtension):
 
         if not 'username' in self.config:
             self.config['username'] = self.website.slug
+            
+        if not 'system_user' in self.config:
+            self.config['system_user'] = ""
+
+        if not 'system_group' in self.config:
+            self.config['system_group'] = ""
+
 
         if not self.config['created']:
             self.config['password'] = str(uuid.uuid4())

--- a/vh-pureftpd/pureftpd.py
+++ b/vh-pureftpd/pureftpd.py
@@ -86,7 +86,9 @@ class PureFTPD (MiscComponent):
                 if cfg and cfg['created']:
                     p = subprocess.Popen(
                         [
-                            'pure-pw', 'useradd', cfg['username'], '-u', 'www-data',
+                            'pure-pw', 'useradd', cfg['username'], 
+                            '-u', cfg.get('system_user', 'www-data'),
+                            '-g', cfg.get('system_group', 'www-data'),
                             '-d', cfg.get('path', None) or website.root,
                         ],
                         stdin=subprocess.PIPE


### PR DESCRIPTION
This patch allows users to bind any system account/group to pureftpd virtual user. If no value is entered, the setup fallbacks to www-data and thus retains backwards compatibility.

Fixes  #266