### PR TITLE
Add json datatype and switch $server_name by $host in nginx_template.

### DIFF
--- a/vh-nginx/nginx_templates.py
+++ b/vh-nginx/nginx_templates.py
@@ -99,7 +99,7 @@ fastcgi_param   REMOTE_ADDR             $remote_addr;
 fastcgi_param   REMOTE_PORT             $remote_port;
 fastcgi_param   SERVER_ADDR             $server_addr;
 fastcgi_param   SERVER_PORT             $server_port;
-fastcgi_param   SERVER_NAME             $server_name;
+fastcgi_param   SERVER_NAME             $host;
 
 fastcgi_param   HTTPS                   $https;
 
@@ -122,6 +122,7 @@ types {
     image/x-icon                          ico;
     image/x-jng                           jng;
     image/vnd.wap.wbmp                    wbmp;
+    application/json                      json;
     application/java-archive              jar war ear;
     application/mac-binhex40              hqx;
     application/pdf                       pdf;


### PR DESCRIPTION
$server_name contains the virtualhost's domains. If multiple domains are specified, it is set to the first one. $host contains the actual domain the request came from, with fallback to the virtualhost's domains.

json content-type was missing.