### PR TITLE
Quick fix to allow dynamic modules on nginx

### DIFF
--- a/vh-nginx/nginx.py
+++ b/vh-nginx/nginx.py
@@ -39,6 +39,7 @@ class NginxWebserver (WebserverComponent):
         self.config_file_proxy = '/etc/nginx/proxy.conf'
         self.config_vhost_root = '/etc/nginx/conf.d'
         self.config_custom_root = '/etc/nginx.custom.d'
+	self.config_modules_root = '/etc/nginx.modules.d'
         self.lib_path = '/var/lib/nginx'
 
     def __generate_website_location(self, ws, location):
@@ -172,6 +173,9 @@ class NginxWebserver (WebserverComponent):
 
         if not os.path.exists(self.config_custom_root):
             os.mkdir(self.config_custom_root, 755)
+
+        if not os.path.exists(self.config_modules_root):
+            os.mkdir(self.config_modules_root, 755)
 
         open(self.config_file, 'w').write(TEMPLATE_CONFIG_FILE)
         open(self.config_file_mime, 'w').write(TEMPLATE_CONFIG_MIME)

--- a/vh-nginx/nginx_templates.py
+++ b/vh-nginx/nginx_templates.py
@@ -8,6 +8,7 @@ user %(user)s %(user)s;
 pid /var/run/nginx.pid;
 worker_processes %(workers)s;
 worker_rlimit_nofile 100000;
+include /etc/nginx.modules.d/*.conf;
 
 events {
     worker_connections  4096;


### PR DESCRIPTION
When you need to use Dynamic Modules on Nginx, you must put at top of nginx.conf to get loaded, if not you get a message like "[emerg] "load_module" directive is specified too late in /etc/nginx/nginx.conf", so a quick fix to avoid config be rewrited is this little fix, so you can add dynamic modules with something like:

`ln -s /usr/share/nginx/modules-available/mod-custommodule.conf /etc/nginx.modules.d/custommodule.conf`

And its all.

