### PR TITLE
Allow SVG gzip compression

### DIFF
--- a/vh-nginx/nginx_templates.py
+++ b/vh-nginx/nginx_templates.py
@@ -37,7 +37,7 @@ http {
     gzip_proxied any;
     gzip_min_length 256;
     gzip_comp_level 4;
-    gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/javascript text/x-js;
+    gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/javascript text/x-js image/svg+xml;
 
     server_names_hash_bucket_size 128;
 


### PR DESCRIPTION
Compressing SVG with GZIP improves content download times